### PR TITLE
feat: add JSONPrintingOptionsPretty option

### DIFF
--- a/OCJSONMapper/NSObject+JSONMapper.h
+++ b/OCJSONMapper/NSObject+JSONMapper.h
@@ -9,7 +9,8 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_OPTIONS(NSUInteger, JSONPrintingOptions) {
-    JSONPrintingOptionsKeepNull = 1
+    JSONPrintingOptionsKeepNull = 1,
+    JSONPrintingOptionsPretty = 2
 };
 
 @interface NSObject (JSONMapper)

--- a/OCJSONMapper/NSObject+JSONMapper.m
+++ b/OCJSONMapper/NSObject+JSONMapper.m
@@ -255,6 +255,12 @@
 }
 
 - (NSString*)JSONString:(JSONPrintingOptions)options {
+    return [self JSONString:options level:@""];
+}
+    
+    // MARK: private methods
+
+- (NSString*)JSONString:(JSONPrintingOptions)options level:(NSString*)level{
     if (self == nil || [self isKindOfClass:NSNull.class])
         return @"null";
 
@@ -265,39 +271,48 @@
     }
 
     if ([self isKindOfClass:NSArray.class])
-        return [self JSONStringFromArray:options];
+        return [self JSONStringFromArray:options level:level];
 
     if ([self isKindOfClass:NSDictionary.class])
-        return [self JSONStringFromDictionary:options];
+        return [self JSONStringFromDictionary:options level:level];
 
-    return [self JSONStringFromObject:options];
+    return [self JSONStringFromObject:options level:level];
 }
 
-- (NSString*)JSONString:(Property*)property options:(JSONPrintingOptions)options{
+- (NSString*)JSONString:(Property*)property options:(JSONPrintingOptions)options level:(NSString*)level {
     if ([self isBoolean:property]) {
         return ((NSNumber*)self).boolValue ? @"true" : @"false";
     } else if ([self isKindOfClass:NSNumber.class]) {
         return ((NSNumber*)self).stringValue;
     }
 
-    return [self JSONString:options];
+    return [self JSONString:options level:level];
 }
 
-- (NSString*)JSONStringFromArray:(JSONPrintingOptions)options {
+- (NSString*)JSONStringFromArray:(JSONPrintingOptions)options level:(NSString*)level {
     NSMutableString* buffer = [NSMutableString string];
+    NSString *extraPadding = [level stringByAppendingString:@"\t"];
     [buffer appendString:@"["];
     for (id item in (NSArray*)self) {
         if (buffer.length > 1)
             [buffer appendString:@","];
-        [buffer appendString:[item JSONString:options]];
+        
+        if (options & JSONPrintingOptionsPretty) {
+            [buffer appendFormat:@"\r%@", extraPadding];
+        }
+        [buffer appendString:[item JSONString:options level:extraPadding]];
+    }
+    if (options & JSONPrintingOptionsPretty) {
+        [buffer appendFormat:@"\r%@", level];
     }
     [buffer appendString:@"]"];
     return buffer;
 }
 
-- (NSString*)JSONStringFromDictionary:(JSONPrintingOptions)options {
+- (NSString*)JSONStringFromDictionary:(JSONPrintingOptions)options  level:(NSString*)level {
     NSDictionary* dic = (NSDictionary*)self;
     NSMutableString* buffer = [NSMutableString string];
+    NSString *extraPadding = [level stringByAppendingString:@"\t"];
     [buffer appendString:@"{"];
     for (NSString* key in dic.allKeys) {
         NSString* propertyName = key;
@@ -316,15 +331,24 @@
         if ([self conformsToProtocol:@protocol(JSONMapper)])
             propertyName = [((id<JSONMapper>)self) remapPropertyName:propertyName];
 
-        [buffer appendString:[NSString stringWithFormat:@"\"%@\": %@", propertyName, [value JSONString:options]]];
+        if (options & JSONPrintingOptionsPretty) {
+            [buffer appendFormat:@"\r%@", extraPadding];
+        }
+
+        NSString *jsonValue = [value JSONString:options level:extraPadding];
+        [buffer appendString:[NSString stringWithFormat: @"\"%@\": %@", propertyName, jsonValue]];
     }
 
+    if (options & JSONPrintingOptionsPretty) {
+        [buffer appendFormat:@"\r%@", level];
+    }
     [buffer appendString:@"}"];
     return buffer;
 }
 
-- (NSString*)JSONStringFromObject:(JSONPrintingOptions)options {
+- (NSString*)JSONStringFromObject:(JSONPrintingOptions)options level:(NSString*)level {
     NSMutableString* buffer = [NSMutableString string];
+    NSString *extraPadding = [level stringByAppendingString:@"\t"];
     [buffer appendString:@"{"];
     for (Property* property in [self properties]) {
         id value = [self valueForKey:property.name];
@@ -342,8 +366,16 @@
         NSString* propertyName = property.name;
         if ([self conformsToProtocol:@protocol(JSONMapper)])
             propertyName = [((id<JSONMapper>)self) remapPropertyName:propertyName];
-
-        [buffer appendString:[NSString stringWithFormat:@"\"%@\": %@", propertyName, [value JSONString:property options:options]]];
+        
+        if (options & JSONPrintingOptionsPretty) {
+            [buffer appendFormat:@"\r%@", extraPadding];
+        }
+        NSString *jsonValue = [value JSONString:property options:options level:extraPadding];
+        [buffer appendString:[NSString stringWithFormat:@"\"%@\": %@", propertyName, jsonValue]];
+    }
+    
+    if (options & JSONPrintingOptionsPretty) {
+        [buffer appendFormat:@"\r%@", level];
     }
     [buffer appendString:@"}"];
     return buffer;

--- a/OCJSONMapper/NSObject+JSONMapper.m
+++ b/OCJSONMapper/NSObject+JSONMapper.m
@@ -258,6 +258,10 @@
     return [self JSONString:options level:@""];
 }
     
+#pragma mark - Static constants
+
+static NSString *const PaddingSymbol = @"  ";
+
 #pragma mark - Private helper methods
 
 - (NSString*)JSONString:(JSONPrintingOptions)options level:(NSString*)level{
@@ -291,7 +295,7 @@
 
 - (NSString*)JSONStringFromArray:(JSONPrintingOptions)options level:(NSString*)level {
     NSMutableString* buffer = [NSMutableString string];
-    NSString *extraPadding = [level stringByAppendingString:@"\t"];
+    NSString *extraPadding = [level stringByAppendingString:PaddingSymbol];
     [buffer appendString:@"["];
     for (id item in (NSArray*)self) {
         if (buffer.length > 1)
@@ -312,7 +316,7 @@
 - (NSString*)JSONStringFromDictionary:(JSONPrintingOptions)options  level:(NSString*)level {
     NSDictionary* dic = (NSDictionary*)self;
     NSMutableString* buffer = [NSMutableString string];
-    NSString *extraPadding = [level stringByAppendingString:@"\t"];
+    NSString *extraPadding = [level stringByAppendingString:PaddingSymbol];
     [buffer appendString:@"{"];
     for (NSString* key in dic.allKeys) {
         NSString* propertyName = key;
@@ -348,7 +352,7 @@
 
 - (NSString*)JSONStringFromObject:(JSONPrintingOptions)options level:(NSString*)level {
     NSMutableString* buffer = [NSMutableString string];
-    NSString *extraPadding = [level stringByAppendingString:@"\t"];
+    NSString *extraPadding = [level stringByAppendingString:PaddingSymbol];
     [buffer appendString:@"{"];
     for (Property* property in [self properties]) {
         id value = [self valueForKey:property.name];

--- a/OCJSONMapper/NSObject+JSONMapper.m
+++ b/OCJSONMapper/NSObject+JSONMapper.m
@@ -258,7 +258,7 @@
     return [self JSONString:options level:@""];
 }
     
-    // MARK: private methods
+#pragma mark - Private helper methods
 
 - (NSString*)JSONString:(JSONPrintingOptions)options level:(NSString*)level{
     if (self == nil || [self isKindOfClass:NSNull.class])


### PR DESCRIPTION
## Open PR

### Added

* JSONPrintingOptionsPretty

### Example

```Objc
      NSLog(@"\r%@", [myObject JSONString: JSONPrintingOptionsPretty]);
```


### Output

100% compatible with Atom `JSON Prettify` feature

```json
{
  "property1": 1,
  "property2": {
    "timeIntervalSinceReferenceDate": 568719350
  },
  "property3": "category",
  "_hidenproperty": "I am hiden",
  "arrayProperty": [
    {
      "property1": 41,
      "property2": {
        "timeIntervalSinceReferenceDate": 568719350
      },
      "property3": "item 1"
    },
    {
      "property1": 42,
      "property2": {
        "timeIntervalSinceReferenceDate": 568719350
      },
      "property3": "item 2"
    },
    {
      "property1": 43,
      "property2": {
        "timeIntervalSinceReferenceDate": 568719350
      },
      "property3": "item 3"
    }
  ],
  "objectProperty": {
    "property1": 0,
    "property2": {
      "timeIntervalSinceReferenceDate": 568719350
    },
    "property3": "inner object"
  }
}
```

